### PR TITLE
2h to 1w

### DIFF
--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -1,7 +1,7 @@
 const jwt = require('jsonwebtoken');
 
 const secret = process.env.APP_SECRET || 'mysecretssshhhhhhh';
-const expiration = '2h';
+const expiration = process.env.MAX_TOKEN_AGE || '1w';
 
 module.exports = {
   authMiddleware: function ({ req }) {


### PR DESCRIPTION
Token is now valid for "1w" ie 1 week for development env.  Can also define as an environment variable for production.