### PR TITLE
prevent double/triple/etc canvas from being created

### DIFF
--- a/client/src/utils/initBookLayer.js
+++ b/client/src/utils/initBookLayer.js
@@ -66,7 +66,13 @@ export function init() {
         scene.add(model)
     })
 // Renders image to the page and animates them
-	renderer = new THREE.WebGLRenderer( { antialias: true } );
+        if (global.renderer) {
+                renderer = global.renderer
+        } else {
+                renderer = new THREE.WebGLRenderer({ antialias: true });
+                global.renderer = renderer
+        }
+        // renderer = new THREE.WebGLRenderer( { antialias: true } );
 	renderer.setSize( window.innerWidth, window.innerHeight );
 	renderer.setAnimationLoop( animation );
         renderer.setClearColor( 0x272727, 1 );


### PR DESCRIPTION
When navigating back and forth to LandingPage it creates a new canvas each time.  

Fixed it to check for `global.renderer` first, if does not exist create new `renderer`